### PR TITLE
Fix terrain feature lookup and neighbor analysis

### DIFF
--- a/hex_grid.py
+++ b/hex_grid.py
@@ -16,7 +16,12 @@ class HexGrid:
     }
 
     DEFAULT_TERRAIN_FEATURES = {
-        'grassland': ['savanna', 'meadow', 'farmland'],
+        # Use terrain type names as keys so features can be looked up correctly.
+        # Previously, the dictionary used the key 'grassland', but the rest of
+        # the code refers to the terrain type as 'grass'. Because of this
+        # mismatch, grass tiles never received any features. Updating the key
+        # ensures grass terrain can have associated features.
+        'grass': ['savanna', 'meadow', 'farmland'],
         'plains': ['plateaus', 'hills', 'riverbank'],
         'desert': ['oasis', 'hills', 'dunes'],
         'snow': ['ice', 'glaciers'],
@@ -74,6 +79,17 @@ class HexGrid:
     def get_neighbor_types(self, row, col):
         # Retrieve the terrain types of neighboring tiles
         return [self.grid[r][c].terrain_type for r, c in self.get_neighbor_coords(row, col)]
+
+    def most_common_neighbor_type(self, row, col):
+        """Return the most common terrain type among neighboring tiles.
+
+        If the tile has no neighbors (e.g., a 1x1 grid), ``None`` is returned.
+        """
+        neighbor_types = self.get_neighbor_types(row, col)
+        if not neighbor_types:
+            return None
+        # Compute the most frequent terrain type among neighbors
+        return max(set(neighbor_types), key=neighbor_types.count)
 
     def choose_terrain_type(self, row, col):
         # Determine the terrain type of a tile based on its neighbors

--- a/map_generator.py
+++ b/map_generator.py
@@ -1,4 +1,5 @@
 from hex_grid import HexGrid
+from hex_tile import HexTile
 from map_visualizer import display_map
 
 def generate_and_display_map(rows, cols, default_terrain='grass', filename='static/map.png'):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# Ensure the parent directory (project root) is on sys.path so tests can
+# import the project modules when executed without installing the package.
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)


### PR DESCRIPTION
## Summary
- Correct terrain feature mapping for grass tiles so features like woods and meadows can be assigned
- Add `most_common_neighbor_type` helper to `HexGrid` for analyzing adjacent tiles
- Export `HexTile` from `map_generator` and ensure tests can import project modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689802d894688327bb1dd972716481f5